### PR TITLE
fix issue of illegal group name on macOS

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -5,7 +5,6 @@ SDRUNDIR=$(CURDIR)/sshdata.run
 .PHONY: config
 config:
 	cp -rf $(SSHDATA) $(SDRUNDIR)
-	sudo chown -R root:root $(SDRUNDIR)
 	sudo chmod -R 500 $(SDRUNDIR)/*
 	cp $(ENV_TEMP) $(ENV)
 	# add extra env variables


### PR DESCRIPTION

fix the issue of illegal group name on macOS

I am not quick sure whether this line is necessary. It works for me.
`sudo chown -R root:root $(SDRUNDIR)`